### PR TITLE
Trigger change events when filling forms

### DIFF
--- a/qute-keepassxc
+++ b/qute-keepassxc
@@ -246,11 +246,15 @@ def make_js_code(username, password):
                 if (isVisible(input) && (input.type == "text" || input.type == "email")) {
                     input.focus();
                     input.value = %s;
+                    input.dispatchEvent(new Event('input', { 'bubbles': true }));
+                    input.dispatchEvent(new Event('change', { 'bubbles': true }));
                     input.blur();
                 }
                 if (input.type == "password") {
                     input.focus();
                     input.value = %s;
+                    input.dispatchEvent(new Event('input', { 'bubbles': true }));
+                    input.dispatchEvent(new Event('change', { 'bubbles': true }));
                     input.blur();
                 }
             }


### PR DESCRIPTION
After posting #3, I kept digging and apparently, keepassxc-browser's solution seems to work on the two examples I could test (discord and a company website)

https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-browser/content/keepassxc-browser.js#L1525

Hope that helps :)