### PR TITLE
show keepassxc login if database is locked

### DIFF
--- a/qute-keepassxc
+++ b/qute-keepassxc
@@ -91,7 +91,7 @@ class KeepassXC:
             action = 'test-associate',
             id     = self.id,
             key    = base64.b64encode(self.id_key.public_key.encode()).decode('utf-8')
-        ))
+        ), triggerUnlock = 'true')
         return self.recv_msg()['success'] == 'true'
 
     def associate(self):


### PR DESCRIPTION
The browser plugin for Firefox / Chrome pops up the keepassxc login screen if the database is locked while trying to insert a password, which is quite convenient in my opinion.
Unfortunately keepassxc-protocol doesn't seem to implement a message for that. The approach of simply calling keepassxc seems rather blunt but works for me.